### PR TITLE
Mod to add missing recipies to EMILoot recipe tree

### DIFF
--- a/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/bossesrise_underworld_knight.json
+++ b/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/bossesrise_underworld_knight.json
@@ -1,0 +1,11 @@
+{
+  "loot_table_id": "block_factorys_bosses:entities/underworld_knight",
+  "mob_id": "block_factorys_bosses:underworld_knight",
+  "context_type": "ENTITY",
+  "entries": [
+    {
+      "item": "block_factorys_bosses:knight_sword",
+      "weight": 1
+    }
+  ]
+}

--- a/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/guling_sentinel_heavy.json
+++ b/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/guling_sentinel_heavy.json
@@ -1,0 +1,10 @@
+{
+  "loot_table_id": "eeeabsmobs:entities/guling_sentinel_heavy",
+  "context_type": "ENTITY",
+  "entries": [
+    {
+      "item": "eeeabsmobs:ancient_drive_crystal",
+      "weight": 1
+    }
+  ]
+}

--- a/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/knightquest_lizzy.json
+++ b/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/knightquest_lizzy.json
@@ -1,0 +1,15 @@
+{
+  "loot_table_id": "knightquest:entities/lizzy",
+  "entries": [
+    {
+      "item": "knightquest:lizzy_scale",
+      "weight": 1,
+      "conditions": [
+        {
+          "type": "random_chance",
+          "chance": 0.50
+        }
+      ]
+    }
+  ]
+}

--- a/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/knightquest_ratman.json
+++ b/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/knightquest_ratman.json
@@ -1,0 +1,16 @@
+{
+  "loot_table_id": "knightquest:entities/ratman",
+  "context_type": "ENTITY",
+  "entries": [
+    {
+      "item": "knightquest:ratman_eye",
+      "weight": 1,
+      "conditions": [
+        {
+          "type": "random_chance",
+          "chance": 0.50
+        }
+      ]
+    }
+  ]
+}

--- a/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/terramity_gob.json
+++ b/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/terramity_gob.json
@@ -1,0 +1,10 @@
+{
+  "loot_table_id": "terramity:entities/gob",
+  "context_type": "ENTITY",
+  "entries": [
+    {
+      "item": "lethality:skysplitter_sword",
+      "weight": 1
+    }
+  ]
+}

--- a/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/terramity_gundalf.json
+++ b/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/terramity_gundalf.json
@@ -1,0 +1,10 @@
+{
+  "loot_table_id": "terramity:entities/gundalf",
+  "context_type": "ENTITY",
+  "entries": [
+    {
+      "item": "lethality:sword_of_majesty",
+      "weight": 1
+    }
+  ]
+}

--- a/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/terramity_super_sniffer.json
+++ b/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/terramity_super_sniffer.json
@@ -1,0 +1,10 @@
+{
+  "loot_table_id": "terramity:entities/super_sniffer",
+  "context_type": "ENTITY",
+  "entries": [
+    {
+      "item": "lethality:sword_of_acclaim",
+      "weight": 1
+    }
+  ]
+}

--- a/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/terramity_trial_guardian.json
+++ b/kubejs/data/emi_loot_registry/emi_loot_suppliers/entities/terramity_trial_guardian.json
@@ -1,0 +1,10 @@
+{
+  "loot_table_id": "terramity:entities/trial_guardian",
+  "context_type": "ENTITY",
+  "entries": [
+    {
+      "item": "lethality:sword_of_splendor",
+      "weight": 1
+    }
+  ]
+}


### PR DESCRIPTION
There are many items that are missing recipes in EMILoot such as terramity sword, simply more swords, knight sword, etc.
That happends due to bunch of mods add their loot drops not not via loot tables but via loot modifiers and these modifiers can't be parsed by EMI to add to it's recipe.

This mod relies on custom datapacks with loot drops definitions to inject them to specified loot tables - https://www.curseforge.com/minecraft/mc-mods/loot-registry

This is server-side mod, so it should be added to both client and server

<img width="555" height="334" alt="image" src="https://github.com/user-attachments/assets/fe0542f9-2f59-46cf-a714-dde085a80bff" />

